### PR TITLE
Fixed namespace inconsistency

### DIFF
--- a/source/SystemInfo.cs
+++ b/source/SystemInfo.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace nanoFramework.Runtime.Hardware
+namespace nanoFramework.Runtime.Native
 {
     /// <summary>
     /// Provides information about the system.

--- a/source/nanoFramework.Runtime.Native.nfproj
+++ b/source/nanoFramework.Runtime.Native.nfproj
@@ -60,7 +60,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Compile Include="Debug.cs" />
-    <Compile Include="Hardware\SystemInfo.cs" />
+    <Compile Include="SystemInfo.cs" />
     <Compile Include="ExecutionConstraint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RTC.cs" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- SystemInfo was under nanoFramework.Runtime.Hardware namespace which is inconsistent with the general namespace of this assembly

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
