### PR TITLE
Fix exception in ResourceUtility constructor

### DIFF
--- a/source/nanoFramework.Runtime.Native/ResourceUtility.cs
+++ b/source/nanoFramework.Runtime.Native/ResourceUtility.cs
@@ -15,13 +15,6 @@ namespace nanoFramework.Runtime.Native
     /// </summary>
     public static class ResourceUtility
     {
-        private static WeakReference s_wr;
-
-        static ResourceUtility()
-        {
-            s_wr = new WeakReference(typeof(ResourceUtility));
-        }
-
         /// <summary>
         /// Gets the value of a specified <see cref="Object"/> resource for the current system culture.
         /// </summary>


### PR DESCRIPTION
## Description
- Remove constructor and static field.

## Motivation and Context
- This static field wasn't being used anywhere. Plus it was causing issues in the constructor depending on the order of the assembly loading.

## How Has This Been Tested?<!-- (if applicable) -->
- Tested with managed resources from samples repo.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>