### PR TITLE
Add Write and WriteLine to Debug class

### DIFF
--- a/source/nanoFramework.Runtime.Native/Debug.cs
+++ b/source/nanoFramework.Runtime.Native/Debug.cs
@@ -20,7 +20,9 @@ namespace nanoFramework.Runtime.Native
         /// <param name="force">true if garbage collection should be forced; otherwise, false.</param>
         /// <returns>The amount of free (unused) memory, in bytes.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
+#pragma warning disable S4200 // Native methods should be wrapped
         extern static public uint GC(bool force);
+#pragma warning restore S4200 // Native methods should be wrapped
 
         /// <summary>
         /// Specifies whether GC (garbage collection) messages are enabled.
@@ -31,7 +33,9 @@ namespace nanoFramework.Runtime.Native
         /// RTM builds (which remove all non essential features) are one of those situations.
         /// </remarks>
         [MethodImpl(MethodImplOptions.InternalCall)]
+#pragma warning disable S4200 // Native methods should be wrapped
         extern static public void EnableGCMessages(bool enable);
+#pragma warning restore S4200 // Native methods should be wrapped
 
         //--//
 
@@ -39,7 +43,7 @@ namespace nanoFramework.Runtime.Native
         /// Causes a break in execution if the specified assertion (condition) evaluates to false.
         /// </summary>
         /// <param name="condition">The condition to be evaluated. If the value is false, program execution stops.</param>
-        [System.Diagnostics.Conditional("DEBUG")]
+        [Conditional("DEBUG")]
         static public void Assert(bool condition)
         {
             if (!condition)
@@ -53,7 +57,7 @@ namespace nanoFramework.Runtime.Native
         /// </summary>
         /// <param name="condition">The condition to be evaluated. If the value is false, program execution stops.</param>
         /// <param name="message">The text to be output if the assertion is false.</param>
-        [System.Diagnostics.Conditional("DEBUG")]
+        [Conditional("DEBUG")]
         static public void Assert(bool condition, string message)
         {
             if (!condition)
@@ -68,7 +72,7 @@ namespace nanoFramework.Runtime.Native
         /// <param name="condition">The condition to be evaluated. If the value is false, program execution stops.</param>
         /// <param name="message">The text to be output if the assertion is false.</param>
         /// <param name="detailedMessage">The detailed message to be displayed if the assertion is false.</param>
-        [System.Diagnostics.Conditional("DEBUG")]
+        [Conditional("DEBUG")]
         static public void Assert(bool condition, string message, string detailedMessage)
         {
             if (!condition)
@@ -76,5 +80,33 @@ namespace nanoFramework.Runtime.Native
                 Debugger.Break();
             }
         }
+
+        /// <summary>
+        /// Writes a message to the trace listeners in the Listeners collection.
+        /// </summary>
+        /// <param name="message">A message to write.</param>
+        /// <remarks>
+        /// In nanoFramework implementation the message is output to Visual Studio debugger window.
+        /// </remarks>
+        [Conditional("DEBUG")]
+#pragma warning disable S4200 // Native methods should be wrapped
+        public static void Write(string message) => WriteLineNative(message, false);
+#pragma warning restore S4200 // Native methods should be wrapped
+
+        /// <summary>
+        /// Writes a message followed by a line terminator to the trace listeners in the Listeners collection.
+        /// </summary>
+        /// <param name="message">A message to write.</param>
+        /// <remarks>
+        /// In nanoFramework implementation the message is output to Visual Studio debugger window.
+        /// </remarks>
+        [Conditional("DEBUG")]
+#pragma warning disable S4200 // Native methods should be wrapped
+        public static void WriteLine(string message) => WriteLineNative(message, true);
+#pragma warning restore S4200 // Native methods should be wrapped
+
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        extern static private void WriteLineNative(string text, bool addLineFeed);
     }
 }

--- a/source/nanoFramework.Runtime.Native/Properties/AssemblyInfo.cs
+++ b/source/nanoFramework.Runtime.Native/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.6.1")]
+[assembly: AssemblyNativeVersion("100.0.6.2")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.0-preview.{height}",
+  "version": "1.2.1-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },
@@ -13,8 +13,7 @@
     "^refs/heads/v\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {
-    "setAllVariables": true,
-    "buildNumber": null
+    "setAllVariables": true
   },
   "release": {
     "branchName": "release-v{version}",


### PR DESCRIPTION
## Description
- Add Write and WriteLine mehods to Debug class.
- Bump version to 1.2.1-preview.
- Bump AssemblyNativeVersion to 100.0.6.2.

## Motivation and Context
- Properly implementation of Write and WriteLine to output debug messages. Current implementation using Console.Write is technically wrong as that shouldn't be used in unattended applications according to .NET documentation.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
